### PR TITLE
ci: scope GITGUARDIAN_API_KEY to ggshield-action step only

### DIFF
--- a/.github/workflows/ggshield.yaml
+++ b/.github/workflows/ggshield.yaml
@@ -9,15 +9,19 @@ jobs:
     name: GitGuardian Scan
     runs-on: ubuntu-latest
     # Skip Dependabot PRs (no secret access, only updates dependencies). The
-    # secret-presence check is enforced per-step via `env.GITGUARDIAN_API_KEY`
-    # below, because the `secrets` context isn't available in `if:` expressions.
+    # secret-presence check is enforced per-step via the `GGSHIELD_ENABLED`
+    # boolean (the `secrets` context isn't available in `if:` expressions, so
+    # we surface it as a job-level env value). Only the action step receives
+    # the actual secret, scoped via its own step-level `env`.
     if: github.actor != 'dependabot[bot]'
     env:
-      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      GGSHIELD_ENABLED: ${{ secrets.GITGUARDIAN_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v6
-        if: env.GITGUARDIAN_API_KEY != ''
+        if: env.GGSHIELD_ENABLED == 'true'
         with:
           fetch-depth: 0
       - uses: GitGuardian/ggshield-action@v1
-        if: env.GITGUARDIAN_API_KEY != ''
+        if: env.GGSHIELD_ENABLED == 'true'
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}


### PR DESCRIPTION
## Summary

Refines the graceful-skip pattern landed earlier so the `GITGUARDIAN_API_KEY` secret value is no longer exposed to every step of the ggshield job.

**Before:** job-level `env: { GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }} }` made the secret visible to `actions/checkout` and any future steps in the job.

**After:** job-level env only exposes a boolean (`GGSHIELD_ENABLED: ${{ secrets.GITGUARDIAN_API_KEY != '' }}`); the actual secret value is scoped to the `ggshield-action` step via step-level env.

## Why

Copilot review feedback on tablackburn/YouTubeMusicPS#21 flagged the wider exposure. Adopted there in commit 8af9b36; this PR propagates the same refinement to keep the convention aligned across all template-derived repos.

## Behavior

No functional change when the secret is set (gate evaluates to `'true'` and the action runs as before). Pure defense-in-depth: future additions to the job can't accidentally inherit the secret.

## Test plan

- [ ] CI passes (existing required checks)
- [ ] `GitGuardian Scan` runs (gate evaluates true here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)