### PR TITLE
chore: update auto-merge workflows to include major version bumps

### DIFF
--- a/.github/workflows/auto-merge-bots.yml
+++ b/.github/workflows/auto-merge-bots.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-merge minor and patch updates
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+      - name: Auto-merge dependency updates
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/auto-merge-bots.yml
+++ b/.github/workflows/auto-merge-bots.yml
@@ -12,11 +12,6 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: dependabot/fetch-metadata@v3
-        id: meta
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Auto-merge dependency updates
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:


### PR DESCRIPTION
This PR updates the auto-merge workflow to allow major version bumps for bot updates.